### PR TITLE
Fix photo page re-authentication issue

### DIFF
--- a/src/app/api/check-auth/route.js
+++ b/src/app/api/check-auth/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export async function GET(request) {
+  try {
+    const cookieStore = cookies();
+    const authCookie = cookieStore.get('photoAuth');
+
+    if (authCookie && authCookie.value === 'true') {
+      return NextResponse.json({ isAuthenticated: true });
+    } else {
+      return NextResponse.json({ isAuthenticated: false });
+    }
+  } catch (error) {
+    console.error('Error in check-auth API:', error);
+    return NextResponse.json({ isAuthenticated: false }, { status: 500 });
+  }
+}

--- a/src/app/pages/photo/page.js
+++ b/src/app/pages/photo/page.js
@@ -5,7 +5,6 @@ import Image from "next/image";
 import Link from "next/link";
 import "../../components/font";
 import PasswordProtect from '../../components/PasswordProtect.js';
-import Cookies from 'js-cookie';
 
 export default function PhotoHome() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -15,11 +14,26 @@ export default function PhotoHome() {
   const [isPhotosLoading, setIsPhotosLoading] = useState(false); // For photos fetch
 
   useEffect(() => {
-    const authCookie = Cookies.get('photoAuth');
-    if (authCookie === 'true') {
-      setIsAuthenticated(true);
-    }
-    setIsLoading(false);
+    const checkAuthStatus = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch('/api/check-auth');
+        if (response.ok) {
+          const data = await response.json();
+          setIsAuthenticated(data.isAuthenticated);
+        } else {
+          console.error('Auth check failed:', response.status, response.statusText);
+          setIsAuthenticated(false);
+        }
+      } catch (error) {
+        console.error('Error fetching auth status:', error);
+        setIsAuthenticated(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkAuthStatus();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Improves session persistence for the Photo page. You will no longer need to re-enter the password on every visit if you have a valid session cookie.

The `photoAuth` cookie is set as `HttpOnly` for security, preventing client-side JavaScript from reading it directly. This was causing the page to always show the password prompt.

Changes:
- Added a new API route `/api/check-auth`. This endpoint checks for the `HttpOnly` `photoAuth` cookie on the server and returns your authentication status (`{ isAuthenticated: true/false }`).
- Modified the Photo page component (`src/app/pages/photo/page.js`) to call the `/api/check-auth` endpoint on initial load.
- The client-side component now relies on the response from `/api/check-auth` to determine if you are authenticated, instead of trying to read the cookie directly.
- Removed unused `js-cookie` import from the photo page, as the `HttpOnly` cookie check is now server-side.